### PR TITLE
adding cucumber tests negative scenarios

### DIFF
--- a/src/main/java/com/uw/TrainerWorkloadService/service/TrainerWorkloadManagementService.java
+++ b/src/main/java/com/uw/TrainerWorkloadService/service/TrainerWorkloadManagementService.java
@@ -248,6 +248,9 @@ public class TrainerWorkloadManagementService {
                   logger.error("Invalid trainer username: ");
                   return ResponseEntity.badRequest().body("{\"message\": \"Trainer username must not be blank\"}");
             }
+            if ( trainingRequest.getTrainingDuration() < 0 ){
+                  throw new IllegalArgumentException("Invalid training duration: training duration must be greater than 0");
+            }
             try {
                   // Validate the action type and call the appropriate method in the TrainerWorkloadManagementService
                   String message;

--- a/src/test/java/com/uw/TrainerWorkloadService/steps/ComponentTestSteps.java
+++ b/src/test/java/com/uw/TrainerWorkloadService/steps/ComponentTestSteps.java
@@ -1,6 +1,7 @@
 package com.uw.TrainerWorkloadService.steps;
 
 import com.uw.TrainerWorkloadService.dto.TrainingRequest;
+import com.uw.TrainerWorkloadService.model.Month;
 import com.uw.TrainerWorkloadService.model.TrainerWorkload;
 import com.uw.TrainerWorkloadService.model.YearSummary;
 import com.uw.TrainerWorkloadService.repository.TrainerWorkloadRepository;
@@ -12,6 +13,7 @@ import io.cucumber.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,7 +32,7 @@ public class ComponentTestSteps {
 
       private TrainingRequest trainingRequest;
       private TrainerWorkload trainerWorkload;
-
+      private ResponseEntity<String> response;
 
 
       @Given("a new training request for trainer with username {string}")
@@ -85,6 +87,60 @@ public class ComponentTestSteps {
             assertNotNull(updatedTrainerWorkload, "Trainer workload should be updated with hours removed");
       }
 
+      @When("an add hours request with invalid data is processed")
+      public void anAddHoursRequestWithInvalidDataIsProcessed() {
+            trainingRequest.setTrainingDuration(-5); // Invalid duration
+            Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+                  trainerWorkloadManagementService.processRequest(trainingRequest);
+            });
+            assertTrue(exception.getMessage().contains("Invalid training duration"), "Validation error expected");
+      }
+
+      @Then("the trainer workload should not be updated in the database")
+      public void theTrainerWorkloadShouldNotBeUpdatedInTheDatabase() {
+            TrainerWorkload updatedTrainerWorkload = trainerWorkloadService.getTrainerWorkloadByUsername(trainerWorkload.getTrainerUsername()).orElse(null);
+            assertNotNull(updatedTrainerWorkload, "Trainer workload should exist");
+
+            // Buscar el resumen del año 2021
+            YearSummary yearSummary = updatedTrainerWorkload.getYears().stream()
+                    .filter(summary -> summary.getYear() == 2021)
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(yearSummary, "Year summary for 2021 should exist");
+
+            // Verificar las horas en enero
+            int januaryHours = yearSummary.getHours(Month.JANUARY); // Enero es el mes 1
+            assertEquals(0, januaryHours, "Trainer workload hours for January 2021 should remain unchanged");
+      }
+
+
+      @Given("an invalid training request with missing or incorrect fields")
+      public void anInvalidTrainingRequestWithMissingOrIncorrectFields() {
+            trainingRequest = new TrainingRequest();
+            trainingRequest.setTrainerUsername(null); // Falta el nombre del entrenador
+            trainingRequest.setTrainingDate(LocalDate.of(2021, 3, 1));
+            trainingRequest.setTrainingDuration(-5); // Duración negativa
+            trainingRequest.setActionType("add");
+      }
+      @When("the bad request is processed")
+      public void theRequestBadIsProcessed() {
+            response = trainerWorkloadManagementService.processRequest(trainingRequest);
+
+      }
+      @Then("the system should return an error response")
+      public void theSystemShouldReturnAnErrorResponse() {
+            assertNotNull(response, "ResponseEntity should not be null");
+            assertEquals(400, response.getStatusCodeValue(), "HTTP status should be 400 Bad Request");
+      }
+
+      @Then("an error message should indicate the reason for the invalid request")
+      public void anErrorMessageShouldIndicateTheReasonForTheInvalidRequest() {
+            assertNotNull(response.getBody(), "Response body should not be null");
+            assertTrue(response.getBody().toString().contains("Trainer username must not be blank"),
+                    "Response body should contain the expected error message");
+      }
+
+
       private TrainingRequest createTrainingRequest(String username, LocalDate date, int duration, boolean isActive, String actionType) {
             TrainingRequest request = new TrainingRequest();
             request.setTrainerUsername(username);
@@ -94,4 +150,6 @@ public class ComponentTestSteps {
             request.setActionType(actionType);
             return request;
       }
+
+
 }

--- a/src/test/resources/features/component_test.feature
+++ b/src/test/resources/features/component_test.feature
@@ -14,3 +14,16 @@ Feature: Trainer Workload Service Component Test
     Given an existing trainer workload for trainer with username "Pedro"
     When a remove hours request is processed
     Then the trainer workload should be updated in the database
+
+
+  Scenario: Do not add hours to trainer workload if request data is invalid
+    Given an existing trainer workload for trainer with username "Pedro"
+    When an add hours request with invalid data is processed
+    Then the trainer workload should not be updated in the database
+
+
+  Scenario: Handle invalid request data for workload update
+    Given an invalid training request with missing or incorrect fields
+    When the bad request is processed
+    Then the system should return an error response
+    And an error message should indicate the reason for the invalid request


### PR DESCRIPTION
This pull request introduces validation for training duration and adds comprehensive tests to handle invalid training requests. The most important changes include adding validation for training duration in the service layer, updating the component test steps to handle invalid data, and enhancing the feature file to include scenarios for invalid data handling.

Validation improvements:

* [`src/main/java/com/uw/TrainerWorkloadService/service/TrainerWorkloadManagementService.java`](diffhunk://#diff-a5dd104dbb93e8dd6c085c42a10d425b75d91c88e6d878216112595d8d6ce5adR251-R253): Added validation to check if `trainingRequest.getTrainingDuration()` is less than 0 and throw an `IllegalArgumentException` if true.

Test enhancements:

* [`src/test/java/com/uw/TrainerWorkloadService/steps/ComponentTestSteps.java`](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eR4): Added imports for `Month` and `ResponseEntity`, introduced a `response` field, and added methods to handle invalid training requests and ensure the system returns appropriate error responses. [[1]](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eR4) [[2]](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eR16) [[3]](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eL33-R35) [[4]](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eR90-R143) [[5]](diffhunk://#diff-6b531fef503feb1b95d8caf1e4f6c55a929b6b120b340d74899b4aea8285735eR153-R154)

Feature file updates:

* [`src/test/resources/features/component_test.feature`](diffhunk://#diff-980f435539cef7bfb61563ffae00fb52679768f62ada511339567c1ffab2edfeR17-R29): Added scenarios to ensure that invalid training requests do not update the trainer workload and that the system returns appropriate error messages.